### PR TITLE
Use currently selected xcode instead of hardcoded path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ echo "$bin_name called with arguments: \$@" >> "\$LOG_FILE"
 pushd "$TOOLCHAIN_BIN_DIR" > /dev/null || exit 1
 
 # Execute the original binary, replacing the current shell
-exec "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/$bin_name" "\$@"
+exec "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin/$bin_name" "\$@"
 
 popd  > /dev/null || exit 1
 EOF


### PR DESCRIPTION
This way we don't assume where user keeps the Xcode. Also, folks who rename the Xcode.app will find it easier to use the wrapper script.