### PR TITLE
Change toolchain display name to My Custom Toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ nano Info.plist
 	<key>CreatedDate</key>
 	<date>2024-12-11T21:37:15Z</date>
 	<key>DisplayName</key>
-	<string>Swift 6.0.3 Release 2024-12-10 (a)</string>
+	<string>My Custom Toolchain</string>
 	<key>OverrideBuildSettings</key>
 	<dict>
 		<key>ENABLE_BITCODE</key>


### PR DESCRIPTION
Having the custom toolchain display name `Swift ...` can be misleading. Changing this to `My Custom Toolchain` makes it a bit easier.